### PR TITLE
Fix typos in links to prior art in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ To recompile the tables (this should almost never be needed):
 
 [The EigenMath CAS by George Weigt](http://eigenmath.sourceforge.net/Eigenmath.pdf). Also you might want to check another fork of EigenMath: [SMIB by Philippe Billet](http://smib.sourceforge.net/).
 
-Another CAS of similar nature is [SimPy](http://www.sympy.org/en/index.html) made in Python.
+Another CAS of similar nature is [SymPy](http://www.sympy.org/en/index.html) made in Python.
 
-Two Javascript CAS are [javascript-cas by Anthony Foster](http://www.sympy.org/en/index.html) supporting "differentiation, complex numbers, sums, vectors (dot products, cross products, gradient/curl etc)" and [Coffeequate by Matthew Alger](http://coffeequate.readthedocs.org/) supporting "quadratic and linear equations, simplification of most algebraic expressions, uncertainties propagation, substitutions, variables, constants, and symbolic constants".
+Two Javascript CAS are [javascript-cas by Anthony Foster](https://github.com/aantthony/javascript-cas) supporting "differentiation, complex numbers, sums, vectors (dot products, cross products, gradient/curl etc)" and [Coffeequate by Matthew Alger](http://coffeequate.readthedocs.org/) supporting "quadratic and linear equations, simplification of most algebraic expressions, uncertainties propagation, substitutions, variables, constants, and symbolic constants".
 
 
 # The MIT License (MIT)


### PR DESCRIPTION
Also, have you seen http://algebra.js.org/ ? Unlike Algebrite and both JS CAS'es that you list, instead of a custom string syntax to create expressions, she chose to go the SymPy route of providing constructors to various node types in the host language, which return objects with methods like `.solveFor()` to manipulate.