### PR TITLE
Parentheses and trig funcs for LaTeX print

### DIFF
--- a/sources/print.coffee
+++ b/sources/print.coffee
@@ -464,10 +464,22 @@ print_DOT_codegen = (p) ->
 	accumulator += ")"
 	return accumulator
 
+print_SIN_latex = (p) ->
+	accumulator = print_str("\\sin\\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
+	return accumulator
+
 print_SIN_codegen = (p) ->
 	accumulator = "Math.sin("
 	accumulator += print_expr(cadr(p))
 	accumulator += ")"
+	return accumulator
+
+print_COS_latex = (p) ->
+	accumulator = print_str("\\cos\\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
 	return accumulator
 
 print_COS_codegen = (p) ->
@@ -476,10 +488,22 @@ print_COS_codegen = (p) ->
 	accumulator += ")"
 	return accumulator
 
+print_TAN_latex = (p) ->
+	accumulator = print_str("\\tan\\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
+	return accumulator
+
 print_TAN_codegen = (p) ->
 	accumulator = "Math.tan("
 	accumulator += print_expr(cadr(p))
 	accumulator += ")"
+	return accumulator
+
+print_ARCSIN_latex = (p) ->
+	accumulator = print_str("\\arcsin\\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
 	return accumulator
 
 print_ARCSIN_codegen = (p) ->
@@ -488,10 +512,22 @@ print_ARCSIN_codegen = (p) ->
 	accumulator += ")"
 	return accumulator
 
+print_ARCCOS_latex = (p) ->
+	accumulator = print_str("\\arccos\\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
+	return accumulator
+
 print_ARCCOS_codegen = (p) ->
 	accumulator = "Math.acos("
 	accumulator += print_expr(cadr(p))
 	accumulator += ")"
+	return accumulator
+
+print_ARCTAN_latex = (p) ->
+	accumulator = print_str("\\arctan\\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
 	return accumulator
 
 print_ARCTAN_codegen = (p) ->
@@ -1056,17 +1092,17 @@ print_power = (base, exponent) ->
 		# determining if it needs to be
 		# wrapped in parentheses or not
 		if (isadd(base) || isnegativenumber(base))
-			accumulator += print_str('(')
+			accumulator += (if printMode == PRINTMODE_LATEX then print_str('\\left(') else print_str('('))
 			accumulator += print_expr(base)
-			accumulator += print_str(')')
+			accumulator += (if printMode == PRINTMODE_LATEX then print_str('\\right)') else print_str(')'))
 		else if ( car(base) == symbol(MULTIPLY) || car(base) == symbol(POWER))
 			if printMode != PRINTMODE_LATEX then accumulator += print_str('(')
 			accumulator += print_factor(base, true)
 			if printMode != PRINTMODE_LATEX then accumulator += print_str(')')
 		else if (isnum(base) && (lessp(base, zero) || isfraction(base)))
-			accumulator += print_str('(')
+			accumulator += (if printMode == PRINTMODE_LATEX then print_str('\\left(') else print_str('('))
 			accumulator += print_factor(base)
-			accumulator += print_str(')')
+			accumulator += (if printMode == PRINTMODE_LATEX then print_str('\\right)') else print_str(')'))
 		else
 			accumulator += print_factor(base)
 
@@ -1153,9 +1189,9 @@ print_factor = (p, omitParens) ->
 					accumulator += print_str(')')
 		return accumulator
 	else if (isadd(p))
-		if !omitParens then accumulator += print_str('(')
+		if !omitParens then accumulator += (if printMode == PRINTMODE_LATEX then print_str('\\left(') else print_str('('))
 		accumulator += print_expr(p)
-		if !omitParens then accumulator += print_str(')')
+		if !omitParens then accumulator += (if printMode == PRINTMODE_LATEX then print_str('\\right)') else print_str(')'))
 		return accumulator
 
 	if (car(p) == symbol(POWER))
@@ -1254,26 +1290,44 @@ print_factor = (p, omitParens) ->
 			accumulator += print_DOT_codegen(p)
 			return accumulator
 	else if car(p) == symbol(SIN)
-		if codeGen
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_SIN_latex(p)
+			return accumulator
+		else if codeGen
 			accumulator += print_SIN_codegen(p)
 			return accumulator
 	else if car(p) == symbol(COS)
-		if codeGen
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_COS_latex(p)
+			return accumulator
+		else if codeGen
 			accumulator += print_COS_codegen(p)
 			return accumulator
 	else if car(p) == symbol(TAN)
-		if codeGen
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_TAN_latex(p)
+			return accumulator
+		else if codeGen
 			accumulator += print_TAN_codegen(p)
 			return accumulator
 	else if car(p) == symbol(ARCSIN)
-		if codeGen
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_ARCSIN_latex(p)
+			return accumulator
+		else if codeGen
 			accumulator += print_ARCSIN_codegen(p)
 			return accumulator
 	else if car(p) == symbol(ARCCOS)
-		if codeGen
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_ARCCOS_latex(p)
+			return accumulator
+		else if codeGen
 			accumulator += print_ARCCOS_codegen(p)
 			return accumulator
 	else if car(p) == symbol(ARCTAN)
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_ARCTAN_latex(p)
+			return accumulator
 		if codeGen
 			accumulator += print_ARCTAN_codegen(p)
 			return accumulator

--- a/sources/print.coffee
+++ b/sources/print.coffee
@@ -464,6 +464,12 @@ print_DOT_codegen = (p) ->
 	accumulator += ")"
 	return accumulator
 
+print_LOG_latex = (p) ->
+	accumulator = print_str("\\log \\left(")
+	accumulator += print_expr(cadr(p))
+	accumulator += print_str("\\right)")
+	return accumulator
+
 print_SIN_latex = (p) ->
 	accumulator = print_str("\\sin\\left(")
 	accumulator += print_expr(cadr(p))
@@ -586,6 +592,18 @@ print_INV_codegen = (p) ->
 	accumulator += print_str("inv(")
 	accumulator += print_expr(cadr(p))
 	accumulator += print_str(')')
+	return accumulator
+
+print_INTEGRAL_latex = (p) ->
+	accumulator = ""
+	functionBody = car(cdr(p))
+
+	accumulator = "\\int "
+	accumulator += functionBody
+	accumulator += " \\, \\mathrm{d}"
+	# This works when second arg to integral is provided, but breaks when it isn't
+	accumulator += print_expr(caddr(p))
+
 	return accumulator
 
 print_DEFINT_latex = (p) ->
@@ -1279,6 +1297,9 @@ print_factor = (p, omitParens) ->
 	else if (car(p) == symbol(BINOMIAL) && printMode == PRINTMODE_LATEX)
 		accumulator += print_BINOMIAL_latex(p)
 		return accumulator
+	else if (car(p) == symbol(INTEGRAL) && printMode == PRINTMODE_LATEX)
+		accumulator += print_INTEGRAL_latex(p)
+		return accumulator
 	else if (car(p) == symbol(DEFINT) && printMode == PRINTMODE_LATEX)
 		accumulator += print_DEFINT_latex(p)
 		return accumulator
@@ -1288,6 +1309,10 @@ print_factor = (p, omitParens) ->
 			return accumulator
 		else if codeGen
 			accumulator += print_DOT_codegen(p)
+			return accumulator
+	else if car(p) == symbol(LOG)
+		if printMode == PRINTMODE_LATEX
+			accumulator += print_LOG_latex(p)
 			return accumulator
 	else if car(p) == symbol(SIN)
 		if printMode == PRINTMODE_LATEX

--- a/sources/print.coffee
+++ b/sources/print.coffee
@@ -598,11 +598,28 @@ print_INTEGRAL_latex = (p) ->
 	accumulator = ""
 	functionBody = car(cdr(p))
 
-	accumulator = "\\int "
-	accumulator += functionBody
-	accumulator += " \\, \\mathrm{d}"
-	# This works when second arg to integral is provided, but breaks when it isn't
-	accumulator += print_expr(caddr(p))
+	p = cdr(p)
+	originalIntegral = p
+	numberOfIntegrals = 0
+
+	while iscons(cdr(p))
+		numberOfIntegrals++
+		accumulator += print_str("\\int ")
+		accumulator += print_str(" \\! ")
+		p = cdr(p)
+
+	accumulator += print_expr(functionBody)
+	accumulator += print_str(" \\,")
+	
+	p = originalIntegral
+
+	for i in [1..numberOfIntegrals]
+		theVariable = cdr(p)
+		accumulator += print_str(" \\mathrm{d} ")
+		accumulator += print_expr(car(theVariable))
+		if i < numberOfIntegrals
+			accumulator += print_str(" \\, ")
+		p = cdr(p)
 
 	return accumulator
 
@@ -1176,6 +1193,7 @@ print_factor = (p, omitParens) ->
 	accumulator = ""
 	if (isnum(p))
 		accumulator += print_number(p, false)
+		# accumulator += (if printMode==PRINTMODE_LATEX then print_str('('+p+')') else print_number(p,false))
 		return accumulator
 
 	if (isstr(p))

--- a/sources/print.coffee
+++ b/sources/print.coffee
@@ -418,9 +418,9 @@ print_term = (p) ->
 
 print_subexpr = (p) ->
 	accumulator = ""
-	accumulator += print_char('(')
+	accumulator += if printMode == PRINTMODE_LATEX then print_str('\\left(') else print_char('(')
 	accumulator += print_expr(p)
-	accumulator += print_char(')')
+	accumulator += if printMode == PRINTMODE_LATEX then print_str('\\right)') else print_char(')')
 	return accumulator
 
 print_factorial_function = (p) ->
@@ -1459,9 +1459,9 @@ print_factor = (p, omitParens) ->
 		#	print_str(((struct symbol *) cadr(p))->name)
 		#	return
 		#}
-		accumulator += print_factor(car(p))
+		accumulator += (if printMode==PRINTMODE_LATEX then print_str('\\mathrm{' + print_factor(car(p)) + '}') else print_factor(car(p)))
 		p = cdr(p)
-		if !omitParens then accumulator += print_str('(')
+		if !omitParens then accumulator += (if printMode==PRINTMODE_LATEX then print_str('\\left(') else print_str('('))
 		if (iscons(p))
 			accumulator += print_expr(car(p))
 			p = cdr(p)
@@ -1469,7 +1469,7 @@ print_factor = (p, omitParens) ->
 				accumulator += print_str(",")
 				accumulator += print_expr(car(p))
 				p = cdr(p)
-		if !omitParens then accumulator += print_str(')')
+		if !omitParens then accumulator += (if printMode==PRINTMODE_LATEX then print_str('\\right)') else print_str(')'))
 		return accumulator
 
 	if (p == symbol(DERIVATIVE))

--- a/sources/print.coffee
+++ b/sources/print.coffee
@@ -921,6 +921,14 @@ print_DO_codegen = (p) ->
 
 	return accumulator
 
+print_CHOOSE_latex = (p) ->
+	accumulator = "\\binom{"
+	accumulator += print_expr(cadr(p))
+	accumulator += "}{"
+	accumulator += print_expr(caddr(p))
+	accumulator += "}"
+	return accumulator
+
 print_SETQ_codegen = (p) ->
 	accumulator = ""
 	accumulator += print_expr(cadr(p))
@@ -1461,6 +1469,9 @@ print_factor = (p, omitParens) ->
 		if codeGen
 			accumulator += "Math.round("+print_expr(cadr(p))+")"
 			return accumulator
+	else if (car(p) == symbol(CHOOSE) && printMode == PRINTMODE_LATEX)
+		accumulator += print_CHOOSE_latex(p)
+		return accumulator
 	else if car(p) == symbol(SETQ)
 		if codeGen
 			accumulator += print_SETQ_codegen(p)


### PR DESCRIPTION
Changed trig func prints to TeX equivalents (sin -> \sin), as well as
using \left( instead of ( in TeX mode to make typesetting prettier.