### PR TITLE
Speed up integral table using hashing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,2 +1,2 @@
 
-<script src="dist/algebrite.bundle-for-browser.js"></script>
+<script src="dist/algebrite.bundle-for-browser.js" charset="utf-8"></script>

--- a/sources/is.coffee
+++ b/sources/is.coffee
@@ -346,7 +346,7 @@ isintegerfactor = (p) ->
 
 isNumberOneOverSomething = (p) ->
   if isfraction(p) \
-  && Math.abs(p.q.a.value) == 1
+  && MEQUAL(p.q.a.abs(), 1)
     return 1
   else
     return 0

--- a/sources/test.coffee
+++ b/sources/test.coffee
@@ -180,7 +180,6 @@ Logical-and of predicate expressions.
 
 # and definition
 Eval_and = ->
-  debugger
   wholeAndExpression = p1
   andPredicates = cdr(wholeAndExpression)
   somePredicateUnknown = false


### PR DESCRIPTION
Implement hashing as suggested in #83.
On my machine this speeds up the integral tests by 30x and the defint tests by 24x.
The current tests are all passing, but it might be a good idea to do some more testing on the hashing function to make sure there's no false negatives.