### PR TITLE
Attempt to recreate the npm package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@npm//@bazel/typescript:index.bzl", "ts_project")
 load("@npm//@bazel/esbuild:index.bzl", "esbuild")
 load("gen_tests.bzl", "gen_tests")
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test", "pkg_npm", "copy_to_bin")
 
 # Allow any ts_library rules in this workspace to reference the config
 # Note: if you move the tsconfig.json file to a subdirectory, you can add an alias() here instead
@@ -22,8 +22,26 @@ esbuild(
     name="algebrite",
     deps=[":tsc"],
     entry_point = "index.ts",
+    platform = "node",
+    external = ["big-integer"],
+    tool = select({
+        "@bazel_tools//src/conditions:darwin": "@esbuild_darwin//:bin/esbuild",
+        "@bazel_tools//src/conditions:windows": "@esbuild_windows//:esbuild.exe",
+        "@bazel_tools//src/conditions:linux_x86_64": "@esbuild_linux//:bin/esbuild",
+    }),
+    visibility=["//visibility:public"],
+)
+
+copy_to_bin(
+    name="copy_browser_main",
+    srcs=["sources/browser_main.js"],
+)
+
+esbuild(
+    name="algebrite.bundle-for-browser",
+    deps=[":tsc"],
+    entry_point = ":copy_browser_main",
     minify = True,
-    # https://community.canvaslms.com/t5/Canvas-Basics-Guide/What-are-the-browser-and-computer-requirements-for-Canvas/ta-p/66
     target = "safari13,chrome87,firefox85",
     tool = select({
         "@bazel_tools//src/conditions:darwin": "@esbuild_darwin//:bin/esbuild",
@@ -31,6 +49,16 @@ esbuild(
         "@bazel_tools//src/conditions:linux_x86_64": "@esbuild_linux//:bin/esbuild",
     }),
     visibility=["//visibility:public"],
+)
+
+pkg_npm(
+    name="npm",
+    srcs = ["package.json"],
+    deps = [
+        ":tsc",
+        ":algebrite",
+        ":algebrite.bundle-for-browser",
+    ]
 )
 
 nodejs_test(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -231,8 +231,7 @@ nodejs_test(
         ":tsc",
         "@npm//big-integer",
     ],
-    shard_count = 10,
-    entry_point = ":tests/roots.ts",
+    entry_point = ":tests/roots_slow.ts",
     tags = ["manual"],
 )
 

--- a/index.ts
+++ b/index.ts
@@ -98,7 +98,7 @@ import {
 import { make_hashed_itab } from './sources/integral';
 import { run } from './runtime/run';
 
-export const $: { [key: string]: unknown } = {};
+const $: { [key: string]: unknown } = {};
 $.version = version;
 $.isadd = isadd;
 $.ismultiply = ismultiply;
@@ -325,6 +325,5 @@ const builtin_fns = [
 ];
 
 Array.from(builtin_fns).map(fn => ($[fn] = exec.bind(this, fn)));
-defs.fullDoubleOutput = true;
-(globalThis as any).Algebrite = $;
+export default $;
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "//": "also change the version in the Algebrite variable at the top of defs file",
   "version": "1.3.1",
   "description": "Computer Algebra System in TypeScript",
-  "main": "bazel-bin/algebrite.js",
+  "main": "./algebrite.js",
+  "module": "./index.js",
+  "browser": "./algebrite.bundle-for-browser.js",
   "directories": {
     "test": "tests"
   },

--- a/sources/browser_main.js
+++ b/sources/browser_main.js
@@ -1,0 +1,2 @@
+import Algebrite from '../index';
+globalThis.Algebrite = Algebrite;


### PR DESCRIPTION
Create an npm package containing:
 - the .js files from tsc
 - algebrite.js - a nodejs bundle of all the .js files, but not the external dependencies
 - algebrite.bundle-for-browser.js - a browser bundle including dependencies and minified

`bazel build npm` should produce a directory in dist/bin/npm containing all of this.
Additionally you can do `bazel run npm.pack` to build a tarball and `bazel run npm.publish` to publish to npm.


See https://bazelbuild.github.io/rules_nodejs/Built-ins.html#pkg_npm for more details