### PR TITLE
refactor(Typescript): modify functions to use and return normal arguments

### DIFF
--- a/runtime/defs.ts
+++ b/runtime/defs.ts
@@ -803,6 +803,20 @@ export function noexpand<T extends any[], V>(
   }
 }
 
+// Call a function temporarily setting "expanding" to true
+export function doexpand<T extends any[], V>(
+  func: (...args: T) => V,
+  ...args: T
+): V {
+  const prev_expanding = defs.expanding;
+  defs.expanding = true;
+  try {
+    return func(...args);
+  } finally {
+    defs.expanding = prev_expanding;
+  }
+}
+
 // Call a function temporarily setting "evaluatingPolar" to true
 export function evalPolar<T extends any[], V>(
   func: (...args: T) => V,

--- a/runtime/otherCFunctions.ts
+++ b/runtime/otherCFunctions.ts
@@ -1,5 +1,5 @@
 import { stop } from './run';
-import { push, pop } from './stack';
+import { push } from './stack';
 import { nativeInt } from '../sources/bignum';
 import { isZeroAtomOrTensor } from '../sources/is';
 import {
@@ -12,6 +12,7 @@ import {
   iscons,
   car,
   cdr,
+  U,
 } from './defs';
 import { get_binding } from './symbol';
 import { list } from '../sources/list';
@@ -176,10 +177,8 @@ export function __range__(
 }
 
 // Append one list to another.
-export function append() {
+export function append(p1: U, p2: U) {
   // from https://github.com/gbl08ma/eigenmath/blob/8be989f00f2f6f37989bb7fd2e75a83f882fdc49/src/append.cpp
-  let p2 = pop();
-  let p1 = pop();
   const h = defs.tos;
   while (iscons(p1)) {
     push(car(p1));

--- a/runtime/run.ts
+++ b/runtime/run.ts
@@ -359,7 +359,7 @@ export function findDependenciesInScript(
         }
 
         try {
-          simplifyForCodeGeneration();
+          push(simplifyForCodeGeneration(pop()));
         } catch (error) {
           if (PRINTOUTRESULT) {
             console.log(error);

--- a/sources/bake.ts
+++ b/sources/bake.ts
@@ -3,6 +3,7 @@ import {
   car,
   Cons,
   defs,
+  doexpand,
   FOR,
   isadd,
   iscons,
@@ -23,9 +24,10 @@ import { equaln, ispolyexpandedform, isZeroAtomOrTensor } from './is';
 import { makeList } from './list';
 
 export function bake(p1: U): U {
-  const prev_expanding = defs.expanding;
-  defs.expanding = true;
+  return doexpand(_bake, p1);
+}
 
+function _bake(p1: U): U {
   const s = ispolyexpandedform(p1, symbol(SYMBOL_S));
   const t = ispolyexpandedform(p1, symbol(SYMBOL_T));
   const x = ispolyexpandedform(p1, symbol(SYMBOL_X));
@@ -53,7 +55,6 @@ export function bake(p1: U): U {
     result = p1;
   }
 
-  defs.expanding = prev_expanding;
   return result;
 }
 

--- a/sources/coeff.ts
+++ b/sources/coeff.ts
@@ -3,7 +3,7 @@ import {
   caddr,
   cadr,
   Constants,
-  defs,
+  doexpand,
   NIL,
   symbol,
   SYMBOL_X,
@@ -75,10 +75,6 @@ export function coeff(p: U, x: U): U[] {
       return coefficients;
     }
 
-    const prev_expanding = defs.expanding;
-    defs.expanding = true;
-    p = divide(p, x);
-    defs.expanding = prev_expanding;
-    //console.log("just divided: " + stack[tos-1].toString())
+    p = doexpand(divide, p, x);
   }
 }

--- a/sources/derivative.ts
+++ b/sources/derivative.ts
@@ -75,7 +75,7 @@ import { d_scalar_tensor, d_tensor_scalar, d_tensor_tensor } from './tensor';
 export function Eval_derivative(p1: U) {
   // evaluate 1st arg to get function F
   p1 = cdr(p1);
-  push(Eval(car(p1)));
+  let F = Eval(car(p1));
 
   // evaluate 2nd arg and then...
 
@@ -89,22 +89,19 @@ export function Eval_derivative(p1: U) {
 
   p1 = cdr(p1);
 
+  let X: U, N: U;
   const p2 = Eval(car(p1));
   if (p2 === symbol(NIL)) {
-    push(guess(top()));
-    push(symbol(NIL));
+    X = guess(F);
+    N = symbol(NIL);
   } else if (isNumericAtom(p2)) {
-    push(guess(top()));
-    push(p2);
+    X = guess(F);
+    N = p2;
   } else {
-    push(p2);
+    X = p2;
     p1 = cdr(p1);
-    push(Eval(car(p1)));
+    N = Eval(car(p1));
   }
-
-  let N = pop();
-  let X = pop();
-  let F = pop();
 
   while (true) {
     // p5 (N) might be a symbol instead of a number

--- a/sources/eigen.ts
+++ b/sources/eigen.ts
@@ -12,9 +12,9 @@ import {
   U,
 } from '../runtime/defs';
 import { stop } from '../runtime/run';
-import { pop, push } from '../runtime/stack';
+import { push } from '../runtime/stack';
 import { set_binding, usr_symbol } from '../runtime/symbol';
-import { push_double } from './bignum';
+import { double } from './bignum';
 import { Eval } from './eval';
 import { yyfloat } from './float';
 import { makeList } from './list';
@@ -184,9 +184,7 @@ function EIG_check_arg(
 ):
   | { arg: Tensor<Double>; invalid?: undefined }
   | { arg?: undefined; invalid: U } {
-  push(Eval(cadr(p1)));
-
-  p1 = Eval(yyfloat(pop()));
+  p1 = Eval(yyfloat(Eval(cadr(p1))));
 
   if (!istensor(p1)) {
     return { invalid: p1 };
@@ -290,8 +288,7 @@ function eigen(op: number, p1: Tensor<Double>): [U, U] {
 
     for (let i = 0; i < EIG_N; i++) {
       for (let j = 0; j < EIG_N; j++) {
-        push_double(EIG_yydd[EIG_N * i + j]);
-        D.tensor.elem[EIG_N * i + j] = pop();
+        D.tensor.elem[EIG_N * i + j] = double(EIG_yydd[EIG_N * i + j]);
       }
     }
   }
@@ -302,8 +299,7 @@ function eigen(op: number, p1: Tensor<Double>): [U, U] {
 
     for (let i = 0; i < EIG_N; i++) {
       for (let j = 0; j < EIG_N; j++) {
-        push_double(EIG_yyqq[EIG_N * i + j]);
-        Q.tensor.elem[EIG_N * i + j] = pop();
+        Q.tensor.elem[EIG_N * i + j] = double(EIG_yyqq[EIG_N * i + j]);
       }
     }
   }

--- a/sources/eval.ts
+++ b/sources/eval.ts
@@ -1128,12 +1128,6 @@ function Eval_unit(p1: U) {
   push(p1);
 }
 
-export function Eval_noexpand() {
-  noexpand(() => {
-    push(Eval(pop()));
-  });
-}
-
 // like Eval() except "=" (assignment) is treated
 // as "==" (equality test)
 // This is because

--- a/sources/expand.ts
+++ b/sources/expand.ts
@@ -3,7 +3,7 @@ import {
   caddr,
   cadr,
   Constants,
-  defs,
+  doexpand,
   isadd,
   ismultiply,
   ispower,
@@ -113,16 +113,10 @@ function expand(F: U, X: U): U {
 
   let result: U;
   if (istensor(C)) {
-    const prev_expanding = defs.expanding;
-    defs.expanding = true;
-    const inverse = inv(C);
-    defs.expanding = prev_expanding;
+    const inverse = doexpand(inv, C);
     result = inner(inner(inverse, B), A);
   } else {
-    const prev_expanding = defs.expanding;
-    defs.expanding = true;
-    const arg1 = divide(B, C);
-    defs.expanding = prev_expanding;
+    const arg1 = doexpand(divide, B, C);
     result = multiply(arg1, A);
   }
   return add(result, Q);
@@ -243,10 +237,7 @@ function expand_get_C(p2: U, p9: U): U {
   for (let i = 0; i < n; i++) {
     for (let j = 0; j < n; j++) {
       const arg2 = power(p9, integer(i));
-      const prev_expanding = defs.expanding;
-      defs.expanding = true;
-      const divided = divide(stack[j], arg2);
-      defs.expanding = prev_expanding;
+      const divided = doexpand(divide, stack[j], arg2);
       p4.tensor.elem[n * i + j] = filter(divided, p9);
     }
   }
@@ -334,10 +325,7 @@ function expand_get_CF(p2: U, p5: U, p9: U): U[] {
   if (!Find(p5, p9)) {
     return [];
   }
-  let prev_expanding = defs.expanding;
-  defs.expanding = true;
-  const p8 = trivial_divide(p2, p5);
-  defs.expanding = prev_expanding;
+  const p8 = doexpand(trivial_divide, p2, p5);
   if (ispower(p5)) {
     n = nativeInt(caddr(p5));
     p6 = cadr(p5);
@@ -350,15 +338,10 @@ function expand_get_CF(p2: U, p5: U, p9: U): U[] {
   for (let i = 0; i < n; i++) {
     for (let j = 0; j < d; j++) {
       let arg2 = power(p6, integer(i));
-      prev_expanding = defs.expanding;
-      defs.expanding = true;
-      let arg1 = multiply(p8, arg2);
-      defs.expanding = prev_expanding;
+      let arg1 = doexpand(multiply, p8, arg2);
       arg2 = power(p9, integer(j));
-      prev_expanding = defs.expanding;
-      defs.expanding = true;
-      stack.push(multiply(arg1, arg2));
-      defs.expanding = prev_expanding;
+      const multiplied = doexpand(multiply, arg1, arg2);
+      stack.push(multiplied);
     }
   }
 
@@ -392,10 +375,7 @@ function expand_get_B(p3: U, p4: U, p9: U): U {
   p8.tensor.dim[0] = n;
   for (let i = 0; i < n; i++) {
     const arg2 = power(p9, integer(i));
-    const prev_expanding = defs.expanding;
-    defs.expanding = true;
-    const divided = divide(p3, arg2);
-    defs.expanding = prev_expanding;
+    const divided = doexpand(divide, p3, arg2);
     p8.tensor.elem[i] = filter(divided, p9);
   }
   return p8;

--- a/sources/factorial.ts
+++ b/sources/factorial.ts
@@ -49,35 +49,23 @@ export function factorial(p1: U): U {
 // this function is not actually used, but
 // all these simplifications
 // do happen automatically via simplify
-function simplifyfactorials() {
-  noexpand(simplifyfactorials_);
+function simplifyfactorials(p1: U): U {
+  return noexpand(simplifyfactorials_, p1);
 }
 
-function simplifyfactorials_() {
-  let p1 = pop();
-
+function simplifyfactorials_(p1: U): U {
   if (isadd(p1)) {
-    const temp = p1
-      .tail()
-      .map((el) => {
-        push(el);
-        simplifyfactorials();
-        return pop();
-      })
-      .reduce(add, Constants.zero);
-    push(temp);
-    return;
+    return p1.tail().map(simplifyfactorials).reduce(add, Constants.zero);
   }
 
   if (ismultiply(p1)) {
-    sfac_product(p1);
-    return;
+    return sfac_product(p1);
   }
 
-  push(p1);
+  return p1;
 }
 
-function sfac_product(p1: U) {
+function sfac_product(p1: U): U {
   const s = defs.tos;
 
   let n = 0;
@@ -114,7 +102,7 @@ function sfac_product(p1: U) {
 
   moveTos(defs.tos - n);
 
-  push(p1);
+  return p1;
 }
 
 function sfac_product_f(s: number, a: number, b: number) {

--- a/sources/filter.ts
+++ b/sources/filter.ts
@@ -23,56 +23,45 @@ Remove terms that involve a given symbol or expression. For example...
 */
 export function Eval_filter(p1: U) {
   p1 = cdr(p1);
-  push(Eval(car(p1)));
+  let result = Eval(car(p1));
 
   if (iscons(p1)) {
-    p1.tail().forEach((p) => {
-      const arg2 = Eval(p);
-      const arg1 = pop();
-      push(filter(arg1, arg2));
-    });
+    result = p1.tail().reduce((acc: U, p: U) => filter(acc, Eval(p)), result);
   }
+  push(result);
 }
 
-/*
- For example...
-
-  push(F)
-  push(X)
-  filter()
-  F = pop()
-*/
-export function filter(p1: U, p2: U): U {
-  return filter_main(p1, p2);
+export function filter(F: U, X: U): U {
+  return filter_main(F, X);
 }
 
-function filter_main(p1: U, p2: U): U {
-  if (isadd(p1)) {
-    return filter_sum(p1, p2);
+function filter_main(F: U, X: U): U {
+  if (isadd(F)) {
+    return filter_sum(F, X);
   }
 
-  if (istensor(p1)) {
-    return filter_tensor(p1, p2);
+  if (istensor(F)) {
+    return filter_tensor(F, X);
   }
 
-  if (Find(p1, p2)) {
+  if (Find(F, X)) {
     return Constants.zero;
   }
 
-  return p1;
+  return F;
 }
 
-function filter_sum(p1: U, p2: U) {
-  return iscons(p1)
-    ? p1.tail().reduce((a: U, b: U) => add(a, filter(b, p2)), Constants.zero)
+function filter_sum(F: U, X: U) {
+  return iscons(F)
+    ? F.tail().reduce((a: U, b: U) => add(a, filter(b, X)), Constants.zero)
     : Constants.zero;
 }
 
-function filter_tensor(p1: Tensor, p2: U): U {
-  const n = p1.tensor.nelem;
+function filter_tensor(F: Tensor, X: U): U {
+  const n = F.tensor.nelem;
   const p3 = alloc_tensor(n);
-  p3.tensor.ndim = p1.tensor.ndim;
-  p3.tensor.dim = Array.from(p1.tensor.dim);
-  p3.tensor.elem = p1.tensor.elem.map((el) => filter(el, p2));
+  p3.tensor.ndim = F.tensor.ndim;
+  p3.tensor.dim = Array.from(F.tensor.dim);
+  p3.tensor.elem = F.tensor.elem.map((el) => filter(el, X));
   return p3;
 }

--- a/sources/gcd.ts
+++ b/sources/gcd.ts
@@ -13,7 +13,7 @@ import {
   isrational,
   U,
 } from '../runtime/defs';
-import { pop, push } from '../runtime/stack';
+import { push } from '../runtime/stack';
 import { equal, length, lessp } from '../sources/misc';
 import { subtract } from './add';
 import { gcd_numbers } from './bignum';
@@ -25,19 +25,17 @@ import { power } from './power';
 // Greatest common denominator
 export function Eval_gcd(p1: U) {
   p1 = cdr(p1);
-  push(Eval(car(p1)));
+  let result = Eval(car(p1));
 
   if (iscons(p1)) {
-    p1.tail().forEach((p) => {
-      const arg2 = Eval(p);
-      const arg1 = pop();
-      push(gcd(arg1, arg2));
-    });
+    result = p1.tail().reduce((acc: U, p: U) => gcd(acc, Eval(p)), result);
   }
+  push(result);
 }
 
 export function gcd(p1: U, p2: U): U {
   const prev_expanding = defs.expanding;
+  defs.expanding = true;
   const result = gcd_main(p1, p2);
   defs.expanding = prev_expanding;
   return result;
@@ -45,7 +43,6 @@ export function gcd(p1: U, p2: U): U {
 
 function gcd_main(p1: U, p2: U): U {
   let polyVar: U | false;
-  defs.expanding = true;
 
   if (equal(p1, p2)) {
     return p1;

--- a/sources/gcd.ts
+++ b/sources/gcd.ts
@@ -4,7 +4,7 @@ import {
   car,
   cdr,
   Constants,
-  defs,
+  doexpand,
   isadd,
   iscons,
   ismultiply,
@@ -34,11 +34,7 @@ export function Eval_gcd(p1: U) {
 }
 
 export function gcd(p1: U, p2: U): U {
-  const prev_expanding = defs.expanding;
-  defs.expanding = true;
-  const result = gcd_main(p1, p2);
-  defs.expanding = prev_expanding;
-  return result;
+  return doexpand(gcd_main, p1, p2);
 }
 
 function gcd_main(p1: U, p2: U): U {

--- a/sources/inner.ts
+++ b/sources/inner.ts
@@ -206,32 +206,21 @@ export function Eval_inner(p1: U) {
 
   // now rebuild the arguments, just using the
   // refined operands
-  push(symbol(INNER));
   //console.log "rebuilding the argument ----"
 
-  if (operands.length > 0) {
-    for (let i = 0; i < operands.length; i++) {
-      //console.log "pushing " + operands[i]
-      push(operands[i]);
-    }
-  } else {
-    pop();
+  if (operands.length === 0) {
     push(symbol(SYMBOL_IDENTITY_MATRIX));
     return;
   }
-  //console.log "list(operands.length): " + (operands.length+1)
-  list(operands.length + 1);
-  p1 = pop();
+
+  p1 = makeList(symbol(INNER), ...operands);
 
   p1 = cdr(p1);
-  push(Eval(car(p1)));
+  let result = Eval(car(p1));
   if (iscons(p1)) {
-    p1.tail().forEach((p) => {
-      const arg2 = Eval(p);
-      const arg1 = pop();
-      push(inner(arg1, arg2));
-    });
+    result = p1.tail().reduce((acc: U, p: U) => inner(acc, Eval(p)), result);
   }
+  push(result);
 }
 
 // inner definition

--- a/sources/integral.ts
+++ b/sources/integral.ts
@@ -399,7 +399,7 @@ export function Eval_integral(p1: U) {
 
   // evaluate 1st arg to get function F
   p1 = cdr(p1);
-  push(Eval(car(p1)));
+  let F = Eval(car(p1));
 
   // evaluate 2nd arg and then...
   // example    result of 2nd arg  what to do
@@ -412,21 +412,18 @@ export function Eval_integral(p1: U) {
   p1 = cdr(p1);
 
   const p2 = Eval(car(p1));
+  let N: U, X: U;
   if (p2 === symbol(NIL)) {
-    push(guess(top()));
-    push(symbol(NIL));
+    X = guess(F);
+    N = symbol(NIL);
   } else if (isNumericAtom(p2)) {
-    push(guess(top()));
-    push(p2);
+    X = guess(F);
+    N = p2;
   } else {
-    push(p2);
+    X = p2;
     p1 = cdr(p1);
-    push(Eval(car(p1)));
+    N = Eval(car(p1));
   }
-
-  let N = pop();
-  let X = pop();
-  let F = pop();
 
   while (true) {
     // N might be a symbol instead of a number
@@ -489,14 +486,14 @@ export function Eval_integral(p1: U) {
   push(F);
 }
 
-export function integral(p1: U, p2: U): U {
+export function integral(F: U, X: U): U {
   let integ: U;
-  if (isadd(p1)) {
-    integ = integral_of_sum(p1, p2);
-  } else if (ismultiply(p1)) {
-    integ = integral_of_product(p1, p2);
+  if (isadd(F)) {
+    integ = integral_of_sum(F, X);
+  } else if (ismultiply(F)) {
+    integ = integral_of_product(F, X);
   } else {
-    integ = integral_of_form(p1, p2);
+    integ = integral_of_form(F, X);
   }
   if (Find(integ, symbol(INTEGRAL))) {
     stop('integral: sorry, could not find a solution');
@@ -505,35 +502,36 @@ export function integral(p1: U, p2: U): U {
   return Eval(simplify(integ));
 }
 
-function integral_of_sum(p1: U, p2: U): U {
-  p1 = cdr(p1);
-  let temp = integral(car(p1), p2);
-  if (iscons(p1)) {
-    temp = p1.tail().reduce((a: U, b: U) => add(a, integral(b, p2)), temp);
+function integral_of_sum(F: U, X: U): U {
+  F = cdr(F);
+  let result = integral(car(F), X);
+  if (iscons(F)) {
+    result = F.tail().reduce(
+      (acc: U, b: U) => add(acc, integral(b, X)),
+      result
+    );
   }
-  return temp;
+  return result;
 }
 
-function integral_of_product(p1: U, p2: U): U {
-  const [constantExpr, variableExpr] = partition(p1, p2);
-  return multiply(constantExpr, integral_of_form(variableExpr, p2)); // multiply constant part
+function integral_of_product(F: U, X: U): U {
+  const [constantExpr, variableExpr] = partition(F, X);
+  return multiply(constantExpr, integral_of_form(variableExpr, X)); // multiply constant part
 }
 
-function integral_of_form(p1: U, p2: U): U {
-  const hc = italu_hashcode(p1, p2).toFixed(6);
+function integral_of_form(F: U, X: U): U {
+  const hc = italu_hashcode(F, X).toFixed(6);
   const tab = hashed_itab[hc];
   // console.log('hashcode('+p1+', '+p2+') = ' + hc + ' '+!!tab);
   if (!tab) {
     // breakpoint
     // italu_hashcode(p1, p2)
-    return makeList(symbol(INTEGRAL), p1, p2);
+    return makeList(symbol(INTEGRAL), F, X);
   }
-  push(p1); // free variable
-  push(p2); // input expression
-  transform(tab, false);
+  transform(F, X, tab, false);
   const p3 = pop();
   if (p3 === symbol(NIL)) {
-    return makeList(symbol(INTEGRAL), p1, p2);
+    return makeList(symbol(INTEGRAL), F, X);
   }
   return p3;
 }

--- a/sources/integral.ts
+++ b/sources/integral.ts
@@ -528,8 +528,7 @@ function integral_of_form(F: U, X: U): U {
     // italu_hashcode(p1, p2)
     return makeList(symbol(INTEGRAL), F, X);
   }
-  transform(F, X, tab, false);
-  const p3 = pop();
+  const [p3, _] = transform(F, X, tab, false);
   if (p3 === symbol(NIL)) {
     return makeList(symbol(INTEGRAL), F, X);
   }

--- a/sources/lcm.ts
+++ b/sources/lcm.ts
@@ -1,5 +1,5 @@
 import { gcd } from './gcd';
-import { car, cdr, defs, iscons, U } from '../runtime/defs';
+import { car, cdr, doexpand, iscons, U } from '../runtime/defs';
 import { push } from '../runtime/stack';
 import { Eval } from './eval';
 import { divide, inverse } from './multiply';
@@ -7,21 +7,15 @@ import { divide, inverse } from './multiply';
 // Find the least common multiple of two expressions.
 export function Eval_lcm(p1: U) {
   p1 = cdr(p1);
-  let temp = Eval(car(p1));
+  let result = Eval(car(p1));
   if (iscons(p1)) {
-    temp = p1.tail().reduce((a: U, b: U) => {
-      return lcm(a, Eval(b));
-    }, temp);
+    result = p1.tail().reduce((a: U, b: U) => lcm(a, Eval(b)), result);
   }
-  push(temp);
+  push(result);
 }
 
 export function lcm(p1: U, p2: U): U {
-  const prev_expanding = defs.expanding;
-  defs.expanding = true;
-  const result = yylcm(p1, p2);
-  defs.expanding = prev_expanding;
-  return result;
+  return doexpand(yylcm, p1, p2);
 }
 
 function yylcm(p1: U, p2: U): U {

--- a/sources/legendre.ts
+++ b/sources/legendre.ts
@@ -13,7 +13,7 @@ import {
   symbol,
   U,
 } from '../runtime/defs';
-import { pop, push } from '../runtime/stack';
+import { push } from '../runtime/stack';
 import { square } from '../sources/misc';
 import { subtract } from './add';
 import { integer, rational, nativeInt } from './bignum';

--- a/sources/log.ts
+++ b/sources/log.ts
@@ -34,10 +34,6 @@ export function Eval_log(p1: U) {
 }
 
 export function logarithm(p1: U): U {
-  return yylog(p1);
-}
-
-function yylog(p1: U): U {
   if (p1 === symbol(E)) {
     return Constants.one;
   }

--- a/sources/misc.ts
+++ b/sources/misc.ts
@@ -4,6 +4,7 @@ import {
   car,
   cdr,
   defs,
+  doexpand,
   E,
   iscons,
   isNumericAtom,
@@ -196,11 +197,7 @@ function unique_f(p: U, p1: U, p2: U) {
 }
 
 export function yyexpand(p1: U): U {
-  const prev_expanding = defs.expanding;
-  defs.expanding = true;
-  const result = Eval(p1);
-  defs.expanding = prev_expanding;
-  return result;
+  return doexpand(Eval, p1);
 }
 
 export function exponential(p1: U): U {

--- a/sources/multiply.ts
+++ b/sources/multiply.ts
@@ -163,9 +163,7 @@ function yymultiply(p1: U, p2: U): U {
 
     if (caar(p1) === symbol(OPERATOR) && caar(p2) === symbol(OPERATOR)) {
       push_symbol(OPERATOR);
-      push(cdar(p1));
-      push(cdar(p2));
-      append();
+      append(cdar(p1), cdar(p2));
       cons();
       p1 = cdr(p1);
       p2 = cdr(p2);

--- a/sources/nroots.ts
+++ b/sources/nroots.ts
@@ -11,7 +11,7 @@ import {
   U,
 } from '../runtime/defs';
 import { stop } from '../runtime/run';
-import { moveTos, pop, push, top } from '../runtime/stack';
+import { moveTos, push } from '../runtime/stack';
 import { sort_stack } from '../sources/misc';
 import { add } from './add';
 import { double } from './bignum';
@@ -29,14 +29,14 @@ const NROOTS_YMAX = 101;
 const NROOTS_DELTA = 1.0e-6;
 const NROOTS_EPSILON = 1.0e-9;
 
-function NROOTS_ABS(z: numericRootOfPolynomial) {
+function NROOTS_ABS(z: numericRootOfPolynomial): number {
   return Math.sqrt(z.r * z.r + z.i * z.i);
 }
 
 // random between -2 and 2
 const theRandom = 0.0;
 
-function NROOTS_RANDOM() {
+function NROOTS_RANDOM(): number {
   //theRandom += 0.2
   //return theRandom
   return 4.0 * Math.random() - 2.0;

--- a/sources/roots.ts
+++ b/sources/roots.ts
@@ -57,22 +57,22 @@ const flatten = (arr: any[]) => [].concat(...arr);
 export function Eval_roots(POLY: U) {
   // A == B -> A - B
   let X = cadr(POLY);
+  let POLY1: U;
   if (car(X) === symbol(SETQ) || car(X) === symbol(TESTEQ)) {
-    push(subtract(Eval(cadr(X)), Eval(caddr(X))));
+    POLY1 = subtract(Eval(cadr(X)), Eval(caddr(X)));
   } else {
     X = Eval(X);
     if (car(X) === symbol(SETQ) || car(X) === symbol(TESTEQ)) {
-      push(subtract(Eval(cadr(X)), Eval(caddr(X))));
+      POLY1 = subtract(Eval(cadr(X)), Eval(caddr(X)));
     } else {
-      push(X);
+      POLY1 = X;
     }
   }
 
   // 2nd arg, x
   X = Eval(caddr(POLY));
 
-  const X1 = X === symbol(NIL) ? guess(top()) : X;
-  const POLY1 = pop();
+  const X1 = X === symbol(NIL) ? guess(POLY1) : X;
 
   if (!ispolyexpandedform(POLY1, X1)) {
     stop('roots: 1st argument is not a polynomial');

--- a/sources/round.ts
+++ b/sources/round.ts
@@ -20,10 +20,6 @@ export function Eval_round(p1: U) {
 }
 
 function yround(p1: U): U {
-  return yyround(p1);
-}
-
-function yyround(p1: U) {
   if (!isNumericAtom(p1)) {
     return makeList(symbol(ROUND), p1);
   }

--- a/sources/sgn.ts
+++ b/sources/sgn.ts
@@ -31,11 +31,7 @@ export function Eval_sgn(p1: U) {
   push(result);
 }
 
-export function sgn(p1: U): U {
-  return yysgn(p1);
-}
-
-function yysgn(X: U): U {
+export function sgn(X: U): U {
   if (isdouble(X)) {
     if (X.d > 0) {
       return Constants.one;
@@ -63,15 +59,6 @@ function yysgn(X: U): U {
   if (isnegativeterm(X)) {
     return multiply(makeList(symbol(SGN), negate(X)), Constants.negOne);
   }
-
-  /*
-  push_integer(2)
-  push(X)
-  heaviside()
-  multiply()
-  push(Constants.negOne)
-  add()
-  */
 
   return makeList(symbol(SGN), X);
 }

--- a/sources/simfac.ts
+++ b/sources/simfac.ts
@@ -52,25 +52,17 @@ Then simplify the sum to get
 */
 // simplify factorials term-by-term
 function Eval_simfac(p1: U) {
-  push(Eval(cadr(p1)));
-  simfac();
+  const result = simfac(Eval(cadr(p1)));
+  push(result);
 }
 
 //if 1
-export function simfac() {
-  let p1 = pop();
+export function simfac(p1: U): U {
   if (isadd(p1)) {
-    const terms = p1.tail().map((term) => {
-      push(term);
-      simfac_term();
-      return pop();
-    });
-    push(add_all(terms));
-  } else {
-    push(p1);
-    simfac_term();
+    const terms = p1.tail().map(simfac_term);
+    return add_all(terms);
   }
-  return;
+  return simfac_term(p1);
 }
 
 //else
@@ -107,13 +99,10 @@ simfac(void)
 
 *endif
 */
-function simfac_term() {
-  let p1 = pop();
-
+function simfac_term(p1: U): U {
   // if not a product of factors then done
   if (!ismultiply(p1)) {
-    push(p1);
-    return;
+    return p1;
   }
 
   // push all factors
@@ -124,7 +113,7 @@ function simfac_term() {
     // do nothing
   }
 
-  push(multiply_all_noexpand(factors));
+  return multiply_all_noexpand(factors);
 }
 
 // try all pairs of factors

--- a/sources/simplify.ts
+++ b/sources/simplify.ts
@@ -109,6 +109,7 @@ function runUserDefinedSimplifications(p: U): U {
   let atLeastOneSuccessInRouldOfRulesApplications = true;
   let numberOfRulesApplications = 0;
 
+  let F1 = pop();
   while (
     atLeastOneSuccessInRouldOfRulesApplications &&
     numberOfRulesApplications < MAX_CONSECUTIVE_APPLICATIONS_OF_ALL_RULES
@@ -131,14 +132,12 @@ function runUserDefinedSimplifications(p: U): U {
             `simplify - tos: ${defs.tos} checking pattern: ${eachSimplification} on: ${p1}`
           );
         }
-        const F1 = pop(); // F i.e. input expression
-        success = transform(F1, symbol(NIL), eachSimplification, true);
+        [F1, success] = transform(F1, symbol(NIL), eachSimplification, true);
         if (success) {
           atLeastOneSuccessInRouldOfRulesApplications = true;
         }
-        p1 = top();
         if (DEBUG) {
-          console.log(`p1 at this stage of simplification: ${p1}`);
+          console.log(`p1 at this stage of simplification: ${F1}`);
         }
       }
       if (
@@ -161,7 +160,7 @@ function runUserDefinedSimplifications(p: U): U {
     console.log(`METAA = ${get_binding(symbol(METAA))}`);
     console.log(`METAB = ${get_binding(symbol(METAB))}`);
   }
-  return pop();
+  return F1;
 }
 
 // ------------------------

--- a/sources/sin.ts
+++ b/sources/sin.ts
@@ -43,22 +43,19 @@ export function sine(p1: U): U {
 // decompose sum sin(alpha+beta) into
 // sin(alpha)*cos(beta)+sin(beta)*cos(alpha)
 function sine_of_angle_sum(p1: U): U {
-  //console.log "sin of angle sum ---- "
   let p2 = cdr(p1);
   while (iscons(p2)) {
     const B = car(p2);
     if (isnpi(B)) {
       const A = subtract(p1, B);
       return add(multiply(sine(A), cosine(B)), multiply(cosine(A), sine(B)));
-      //console.log "sin of angle sum end ---- "
     }
     p2 = cdr(p2);
   }
   return sine_of_angle(p1);
 }
-//console.log "sin of angle sum end ---- "
 
-function sine_of_angle(p1: U) {
+function sine_of_angle(p1: U): U {
   if (car(p1) === symbol(ARCSIN)) {
     return cadr(p1);
   }

--- a/sources/sinh.ts
+++ b/sources/sinh.ts
@@ -23,10 +23,6 @@ export function Eval_sinh(p1: U) {
 }
 
 export function ysinh(p1: U): U {
-  return yysinh(p1);
-}
-
-function yysinh(p1: U): U {
   if (car(p1) === symbol(ARCSINH)) {
     return cadr(p1);
   }

--- a/sources/sum.ts
+++ b/sources/sum.ts
@@ -23,6 +23,11 @@ import { Eval, evaluate_integer } from './eval';
 
 // leaves the sum at the top of the stack
 export function Eval_sum(p1: U) {
+  const result = _sum(p1);
+  push(result);
+}
+
+function _sum(p1: U): U {
   // 1st arg
   const body = cadr(p1);
 
@@ -35,15 +40,13 @@ export function Eval_sum(p1: U) {
   // 3rd arg (lower limit)
   const j = evaluate_integer(cadddr(p1));
   if (isNaN(j)) {
-    push(p1);
-    return;
+    return p1;
   }
 
   // 4th arg (upper limit)
   const k = evaluate_integer(caddddr(p1));
   if (isNaN(k)) {
-    push(p1);
-    return;
+    return p1;
   }
 
   // remember contents of the index
@@ -55,8 +58,8 @@ export function Eval_sum(p1: U) {
     set_binding(indexVariable, integer(i));
     temp = add(temp, Eval(body));
   }
-  push(temp);
 
   // put back the index variable to original content
   set_binding(indexVariable, p4);
+  return temp;
 }

--- a/sources/tan.ts
+++ b/sources/tan.ts
@@ -23,10 +23,6 @@ export function Eval_tan(p1: U) {
 }
 
 function tangent(p1: U): U {
-  return yytangent(p1);
-}
-
-function yytangent(p1: U): U {
   if (car(p1) === symbol(ARCTAN)) {
     return cadr(p1);
   }

--- a/sources/transform.ts
+++ b/sources/transform.ts
@@ -192,14 +192,7 @@ export function transform(
 
           if (DEBUG) {
             console.log('tos before recursive transform: ' + defs.tos);
-          }
-
-          if (DEBUG) {
             console.log(`testing: ${secondTerm}`);
-          }
-          //if (secondTerm+"") == "eig(A x,transpose(A x))()"
-          //  breakpoint
-          if (DEBUG) {
             console.log(`about to try to simplify other term: ${secondTerm}`);
           }
           const [t, success] = transform(

--- a/sources/transform.ts
+++ b/sources/transform.ts
@@ -69,10 +69,12 @@ true is successful, false if not.
 //define B p6
 //define C p7
 
-export function transform(s: string[] | U, generalTransform: boolean) {
-  const X = pop(); // X i.e. free variable
-  const F = pop(); // F i.e. input expression
-
+export function transform(
+  F: U,
+  X: U,
+  s: string[] | U,
+  generalTransform: boolean
+) {
   if (DEBUG) {
     console.log(`         !!!!!!!!!   transform on: ${F}`);
   }
@@ -191,8 +193,6 @@ export function transform(s: string[] | U, generalTransform: boolean) {
             console.log('tos before recursive transform: ' + defs.tos);
           }
 
-          push(secondTerm);
-          push_symbol(NIL);
           if (DEBUG) {
             console.log(`testing: ${secondTerm}`);
           }
@@ -201,7 +201,12 @@ export function transform(s: string[] | U, generalTransform: boolean) {
           if (DEBUG) {
             console.log(`about to try to simplify other term: ${secondTerm}`);
           }
-          const success = transform(s, generalTransform);
+          const success = transform(
+            secondTerm,
+            symbol(NIL),
+            s,
+            generalTransform
+          );
           transformationSuccessful = transformationSuccessful || success;
 
           transformedTerms.push(pop());

--- a/sources/transform.ts
+++ b/sources/transform.ts
@@ -75,7 +75,7 @@ export function transform(
   X: U,
   s: string[] | U,
   generalTransform: boolean
-) {
+): [U, boolean] {
   if (DEBUG) {
     console.log(`         !!!!!!!!!   transform on: ${F}`);
   }
@@ -202,7 +202,7 @@ export function transform(
           if (DEBUG) {
             console.log(`about to try to simplify other term: ${secondTerm}`);
           }
-          const success = transform(
+          const [t, success] = transform(
             secondTerm,
             symbol(NIL),
             s,
@@ -210,7 +210,7 @@ export function transform(
           );
           transformationSuccessful = transformationSuccessful || success;
 
-          transformedTerms.push(pop());
+          transformedTerms.push(t);
 
           if (DEBUG) {
             console.log(
@@ -279,19 +279,12 @@ export function transform(
     transformationSuccessful = true;
   } else {
     // transformations failed
-    if (generalTransform) {
-      // result = original expression
-      temp = F;
-    } else {
-      temp = symbol(NIL);
-    }
+    temp = generalTransform ? F : symbol(NIL);
   }
 
   restoreMetaBindings();
 
-  push(temp);
-
-  return transformationSuccessful;
+  return [temp, transformationSuccessful];
 }
 
 function saveMetaBindings() {
@@ -340,7 +333,6 @@ function f_equals_a(
         // skip to the next binding of metas
         continue;
       }
-      push(F); // F = A?
       if (DEBUG) {
         console.log(
           `about to evaluate template expression: ${A} binding METAA to ${get_binding(
@@ -350,12 +342,11 @@ function f_equals_a(
           )} and binding METAX to ${get_binding(symbol(METAX))}`
         );
       }
-      const ans = generalTransform ? noexpand(Eval, A) : Eval(A);
-      const arg1 = pop();
+      const arg2 = generalTransform ? noexpand(Eval, A) : Eval(A);
       if (DEBUG) {
-        console.log(`  comparing ${ans} to: ${arg1}`);
+        console.log(`  comparing ${arg2} to: ${F}`);
       }
-      temp = subtract(arg1, ans);
+      temp = subtract(F, arg2);
       if (isZeroAtomOrTensor(temp)) {
         if (DEBUG) {
           console.log(`binding METAA to ${get_binding(symbol(METAA))}`);

--- a/sources/transpose.ts
+++ b/sources/transpose.ts
@@ -37,17 +37,13 @@ import { multiply } from './multiply';
 // Transpose tensor indices
 export function Eval_transpose(p1: U) {
   const arg1 = Eval(cadr(p1));
-  let arg2: U, arg3: U;
-
-  // add default params if they
-  // have not been passed
-  if (cddr(p1) === symbol(NIL)) {
-    arg2 = Constants.one;
-    arg3 = integer(2);
-  } else {
+  let arg2: U = Constants.one;
+  let arg3: U = integer(2);
+  if (cddr(p1) !== symbol(NIL)) {
     arg2 = Eval(caddr(p1));
     arg3 = Eval(cadddr(p1));
   }
+
   push(transpose(arg1, arg2, arg3));
 }
 

--- a/sources/zero.ts
+++ b/sources/zero.ts
@@ -4,6 +4,10 @@ import { push } from '../runtime/stack';
 import { evaluate_integer } from './eval';
 
 export function Eval_zero(p1: U) {
+  push(_zero(p1));
+}
+
+function _zero(p1: U): U {
   const k: number[] = Array(MAXDIM).fill(0);
 
   let m = 1;
@@ -13,8 +17,7 @@ export function Eval_zero(p1: U) {
       const i = evaluate_integer(el);
       if (i < 1 || isNaN(i)) {
         // if the input is nonsensical just return 0
-        push(Constants.zero);
-        return;
+        return Constants.zero;
       }
       m *= i;
       k[n++] = i;
@@ -22,13 +25,12 @@ export function Eval_zero(p1: U) {
   }
 
   if (n === 0) {
-    push(Constants.zero);
-    return;
+    return Constants.zero;
   }
   p1 = alloc_tensor(m);
   p1.tensor.ndim = n;
   for (let i = 0; i < n; i++) {
     p1.tensor.dim[i] = k[i];
   }
-  push(p1);
+  return p1;
 }


### PR DESCRIPTION
Refactor several files for maintainability.
* remove `push` and `pop` where possible
* add a `doexpand` function similar to the `noexpand`
* refactor `simplify`
* rename variables where made obvious by comments
* delete comments made redundant by variable names or nearby code
* delete commented out code (visible in version control)
* remove one layer of `funcname`, `yfuncname`, `yyfuncname` where possible

risk: medium (some code changes didn't trigger test failures)
merge: squash
